### PR TITLE
Add gofigure:"ignore" support

### DIFF
--- a/gofigure.go
+++ b/gofigure.go
@@ -228,7 +228,9 @@ func (gfg *gofiguration) parseFields(v reflect.Value, t reflect.Type) {
 		if len(tag) > 0 {
 			gfi.keys = getStructTags(string(tag))
 		}
-		gfg.fields[f] = gfi
+		if gfi.keys["gofigure"] != "ignore" {
+			gfg.fields[f] = gfi
+		}
 	}
 }
 


### PR DESCRIPTION
A simple change that allows a field of a struct to be ignored if it is tagged with 
gofigure:"ignore"
This can be useful for unsupported field types or configuration that is rather derived from other parameters, not read directly.